### PR TITLE
Expose ready signal, update `state.listening` correctly

### DIFF
--- a/test.js
+++ b/test.js
@@ -19,17 +19,35 @@ test('initialization', function (t) {
   })
   var stopWatching = Sour.watch(state)
   t.equal(state().listening, true, 'sets listening to true when it starts listening')
-  t.ok(state().active, 'has an active entry')
-  t.ok(Sour.render(state()), 'render returns proper data from syncronous call')
+  t.notOk(state().active, 'does not have an active entry syncronously from init')
 
-  setTimeout(function () {
-    t.ok(Sour.render(state()), 'render returns proper data')
+  Sour.onReady(state, function () {
     t.ok(state().active, 'has an active entry')
 
     stopWatching()
     t.equal(state().listening, false, 'sets listening to false when watching is canceled')
     t.end()
-  }, 500)
+  })
+})
+
+test('initialization without routes', function (t) {
+  var state = Sour()
+
+  t.equal(state().path, '/', 'path defaults to "/"')
+  t.equal(state().listening, false, 'not listening by default')
+
+  var stopWatching = Sour.watch(state)
+  t.equal(state().listening, true, 'sets listening to true when it starts listening')
+  t.notOk(state().active, 'does not have an active entry syncronously from init')
+
+  Sour.onReady(state, function () {
+    t.notOk(state().active, 'has no active entry')
+    t.notOk(Sour.render(state()), 'render results in undefined')
+
+    stopWatching()
+    t.equal(state().listening, false, 'sets listening to false when watching is canceled')
+    t.end()
+  })
 })
 
 test(function (t) {

--- a/test.js
+++ b/test.js
@@ -5,6 +5,33 @@ var Observ = require('observ')
 var watch = require('observ/watch')
 var Sour = require('./')
 
+test('initialization', function (t) {
+  var state = Sour()
+
+  t.equal(state().path, '/', 'path defaults to "/"')
+  t.equal(state().listening, false, 'not listening by default')
+
+  Sour.route(state, {
+    path: '/',
+    render: function () {
+      return true
+    }
+  })
+  var stopWatching = Sour.watch(state)
+  t.equal(state().listening, true, 'sets listening to true when it starts listening')
+  t.ok(state().active, 'has an active entry')
+  t.ok(Sour.render(state()), 'render returns proper data from syncronous call')
+
+  setTimeout(function () {
+    t.ok(Sour.render(state()), 'render returns proper data')
+    t.ok(state().active, 'has an active entry')
+
+    stopWatching()
+    t.equal(state().listening, false, 'sets listening to false when watching is canceled')
+    t.end()
+  }, 500)
+})
+
 test(function (t) {
   t.plan(8)
 


### PR DESCRIPTION
Currently Sour does not ever set the listening flag to true, this properly sets and unsets the value when you start/stop listening
Currently there is no way to differentiate initializing on a 404 versus not being fully initialized, which means if you render synchronously from initialization then you will always render a 404, and if you listen on active then you wont properly render your actual 404's. This adds a ready signal so you can power up your loop based on that signal.

Added a bunch of test cases to demonstrate.
