### PR TITLE
Bind to window.location.hash via options.hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var Struct = require('observ-struct')
 var Observ = require('observ')
 var Path = require('observ-path')
+var Hash = require('observ-location-hash')
 var Table = require('tafel')
 var series = require('run-series')
 var partial = require('ap').partial
@@ -25,7 +26,7 @@ function Router (data) {
   data = data || {}
 
   var state = Struct({
-    path: Path(data.path),
+    path: (data.hash ? Hash : Path)(data.path),
     watching: Observ(false),
     active: Observ(),
     params: Observ({})

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "next-tick": "~0.2.2",
     "observ": "~0.2.0",
     "observ-listen-if": "~1.0.1",
+    "observ-location-hash": "~1.0.2",
     "observ-path": "~1.0.1",
     "observ-readable": "~1.2.1",
     "observ-struct": "~6.0.0",


### PR DESCRIPTION
Uses [observ-location-hash](https://github.com/ajoslin/observ-location-hash) underneath.

...And I'm using this for Cordova support, because Cordova has a lot of issues with pushState-based urls.
