### PR TITLE
Add Router.path to get a route's path

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ Router.onNotFound = NotFoundEvent.listen
 var ErrorEvent = Event()
 Router.onError = ErrorEvent.listen
 
+Router.path = function path (state, route, params) {
+  return store(state).table.path(route, params)
+}
+
 Router.watch = function watch (state, done) {
   if (state.watching()) return
   onPath(state, state.path(), done)

--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,25 @@ Arguments: `err`
 
 Called when any hook errors during a transition. Returns an unlisten function.
 
+
+#### `Sour.path(state, route, [params])` -> `string`
+
+Given a route and its path params, return a string representing the route's path.
+
+#### route
+
+*Required*  
+Type: `object`
+
+A route returned from `Sour.route`
+
+#### params
+
+*Optional*  
+Type: `object`
+
+Params to match against the params in the path of the given route.
+
 ## License
 
 MIT © [Ben Drucker](http://bendrucker.me)

--- a/test/path.js
+++ b/test/path.js
@@ -1,0 +1,40 @@
+'use strict'
+
+var test = require('tape')
+var Router = require('../')
+
+test('get path for route with params', function (t) {
+  var state = Router()
+  var route = Router.route(state, {
+    path: '/foo/:id',
+    render: function () {
+      return 'foo!'
+    }
+  })
+
+  t.equal(Router.path(state, route, {id: 1}), '/foo/1')
+
+  // invalid key
+  t.throws(function () {
+    Router.path(state, {}, {id: 1})
+  })
+
+  // no params
+  t.throws(function () {
+    Router.path(state, route)
+  })
+  t.end()
+})
+
+test('get path for route with no params', function (t) {
+  var state = Router()
+  var route = Router.route(state, {
+    path: '/bar',
+    render: function () {
+      return 'bar!'
+    }
+  })
+
+  t.equal(Router.path(state, route), '/bar')
+  t.end()
+})


### PR DESCRIPTION
``` js
var route = Sour.route(router, {
  path: '/list/:listId/:detailId'
})
Router.path(router, route, {listId: 123, detailId: 234}) // => '/list/123/234'
```
